### PR TITLE
Allow installing binary using make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories("${BLPCONVERTER_SOURCE_DIR}/dependencies/include/"
 add_executable(BLPConverter main.cpp blp.cpp)
 target_link_libraries(BLPConverter freeimage squish)
 set_target_properties(BLPConverter PROPERTIES COMPILE_DEFINITIONS "FREEIMAGE_LIB")
+install(TARGETS BLPConverter RUNTIME DESTINATION bin)
 
 option(WITH_LIBRARY "Compile library" OFF)
 if(WITH_LIBRARY)


### PR DESCRIPTION
The `libblp` library from #3 can be easily installed to the system by using `make install` as opposed to the default `make` which will keep everything neatly in the build folder as described in the README.

However, I completely missed the binary not having an install command. That'd be nifty to have I think.
